### PR TITLE
Cherrypick rope fix

### DIFF
--- a/lua/autorun/server/sv_precision_align.lua
+++ b/lua/autorun/server/sv_precision_align.lua
@@ -861,17 +861,16 @@ function precision_align_constraint_func( len, ply )
         local rope
         const, rope = MakeWireHydraulic( ply, Ent1, Ent2, 0, 0, LPos1, LPos2, width, material, 0, nil )
 
-        if const then
-            controller.MyId = controller:EntIndex()
-            const.MyCrtl = controller:EntIndex()
-            controller:SetConstraint( const )
-            controller:DeleteOnRemove( const )
-        end
+		if const then
+			controller.MyId = controller:EntIndex()
+			const.MyCrtl = controller:EntIndex()
+			controller:SetConstraint( const, rope )
+			controller:DeleteOnRemove( const )
+		end
 
-        if rope then
-            controller:SetRope( rope )
-            controller:DeleteOnRemove( rope )
-        end
+		if rope then
+			controller:DeleteOnRemove( rope )
+		end
 
         -- Remove the existing hydraulic constraint
         if oldconstraint then


### PR DESCRIPTION
Origin: https://github.com/CFC-Servers/precision-alignment/commit/5389356e33fe3dcf64f99b9a51a10b6d1602053e

Error:
```
addons/precision_alignment/lua/autorun/server/sv_precision_align.lua:872: attempt to call method 'SetRope' (a nil value)
   1.  SetRope - [C]:-1
    2.  <unknown> - addons/precision_alignment/lua/autorun/server/sv_precision_align.lua:872
```